### PR TITLE
removing liveness probe for /healthz

### DIFF
--- a/kd/dev/pttg-fs-api-deployment.yaml
+++ b/kd/dev/pttg-fs-api-deployment.yaml
@@ -109,16 +109,6 @@ spec:
         ports:
           - name: http
             containerPort: 8080
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            httpHeaders:
-              - name: X-probe
-                value: kubelet
-          initialDelaySeconds: 240
-          periodSeconds: 20
-          timeoutSeconds: 10
         imagePullPolicy: Always
       volumes:
       - name: secrets


### PR DESCRIPTION
causing continuous restarts - removing during investigation
